### PR TITLE
Fix CPPI isFriend

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -737,6 +737,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 		if debug.getregistry().Player.CPPIGetFriends then
 			E2Lib.replace_function("isFriend", function(owner, player)
 				if owner == nil then return false end
+				if not owner:IsPlayer() then return false end
 				if owner == player then return true end
 
 				local friends = owner:CPPIGetFriends()


### PR DESCRIPTION
For some ungodly reason entities on the map are owner by other entities so running CPPIGetOwner on them throws an error, this fixes that