### PR TITLE
Prevent users from using error causing effects

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -5,7 +5,12 @@ local wire_expression2_effect_burst_rate = CreateConVar( "wire_expression2_effec
 
 -- Use hook E2CanEffect to blacklist/whitelist effects
 local effect_blacklist = {
-	dof_node = true
+	dof_node = true,
+	beer_puke = true,
+	simfphys_exhaust = true,
+	simfphys_backfire = true,
+	rj_bolttrail = true,
+	dond_confetti = true
 }
 
 local function isAllowed( self )


### PR DESCRIPTION
This will solve several errors that can be caused by creating metastruct specific effects with the Expression 2 Tool. While it would probably be better to fix these problems at the source, preventing the user from creating these effects seems more efficient as it requires less code. These effects cannot be created with Starfall as it will cause "unknown particle system" errors and this issue should therefor be solved.

>beer_puke
[ERROR] lua/helpers/puke_effect.lua:81: attempt to call method 'GetAimVector' (a nil value)
1. unknown - lua/helpers/puke_effect.lua:81

>simfphys_exhaust
[ERROR] lua/effects/simfphys_exhaust.lua:27: attempt to call method 'GetTurboCharged' (a nil value)
1. unknown - lua/effects/simfphys_exhaust.lua:27

>simfphys_backfire
NextThink: lua/effects/simfphys_backfire.lua:35: attempt to call method 'GetBackfireSound' (a nil value)
stack traceback:
	lua/effects/simfphys_backfire.lua:35: in function <lua/effects/simfphys_backfire.lua:28>
	[C]: in function 'xpcall'
	lua/includes/modules/hookextras.lua:25: in function 'func'
	lua/includes/modules/hook.lua:171: in function <lua/includes/modules/hook.lua:156>
	[C]: in function 'xpcall'
	lua/includes/modules/hook.lua:213: in function <lua/includes/modules/hook.lua:194>

>rj_bolttrail
[ERROR] lua/weapons/weapon_archerxbow.lua:632: attempt to call method 'GetHit' (a nil value)
1. unknown - lua/weapons/weapon_archerxbow.lua:632

>dond_confetti
[ERROR] lua/entities/mitt_dond_screen.lua:3103: attempt to call method 'GetConfetti' (a nil value)
1. unknown - lua/entities/mitt_dond_screen.lua:3103